### PR TITLE
Add stub Rhythm Tengoku world

### DIFF
--- a/worlds/rhythm_tengoku/__init__.py
+++ b/worlds/rhythm_tengoku/__init__.py
@@ -1,0 +1,67 @@
+from typing import ClassVar
+import os
+
+from BaseClasses import Item, ItemClassification, Location, Region, Tutorial, World
+from worlds.AutoWorld import WebWorld
+
+from .items import item_table, RhythmTengokuItem
+from .locations import location_table, RhythmTengokuLocation
+from .options import RhythmTengokuOptions
+from .rom import RhythmTengokuProcedurePatch, write_tokens
+
+
+class RhythmTengokuWebWorld(WebWorld):
+    tutorials = [Tutorial(
+        "Multiworld Setup Guide",
+        "A guide to setting up Rhythm Tengoku for Archipelago.",
+        "English",
+        "setup_en.md",
+        "setup/en",
+        ["Archipelago"]
+    )]
+
+
+class RhythmTengokuWorld(World):
+    """Basic Archipelago world for Rhythm Tengoku."""
+
+    game = "Rhythm Tengoku"
+    web = RhythmTengokuWebWorld()
+    options_dataclass = RhythmTengokuOptions
+    options: RhythmTengokuOptions
+
+    item_name_to_id = {name: data.code for name, data in item_table.items()}
+    location_name_to_id = {name: data.id for name, data in location_table.items()}
+
+    data_version = 0
+    required_client_version = (0, 4, 6)
+
+    def create_item(self, name: str) -> Item:
+        data = item_table[name]
+        return RhythmTengokuItem(name, data.classification, data.code, self.player)
+
+    def create_regions(self) -> None:
+        menu = Region("Menu", self.player, self.multiworld)
+        self.multiworld.regions.append(menu)
+        region = Region("Rhythm Tengoku", self.player, self.multiworld)
+        self.multiworld.regions.append(region)
+        menu.connect(region)
+        for loc_name, loc in location_table.items():
+            region.locations.append(RhythmTengokuLocation(self.player, loc_name, loc.id, region))
+
+    def create_items(self) -> None:
+        for item_name in item_table:
+            self.multiworld.itempool.append(self.create_item(item_name))
+
+    def set_rules(self) -> None:
+        pass
+
+    def fill_slot_data(self) -> dict:
+        return {"check_type": self.options.check_type.current_key}
+
+    def generate_output(self, output_directory: str) -> None:
+        patch = RhythmTengokuProcedurePatch(player=self.player,
+                                            player_name=self.multiworld.get_player_name(self.player),
+                                            server=self.multiworld.server_address)
+        write_tokens(self, patch)
+        patch.write(os.path.join(output_directory,
+                                 f"{self.multiworld.get_out_file_name_base(self.player)}{patch.patch_file_ending}"))

--- a/worlds/rhythm_tengoku/docs/en_Rhythm_Tengoku.md
+++ b/worlds/rhythm_tengoku/docs/en_Rhythm_Tengoku.md
@@ -1,0 +1,6 @@
+# Rhythm Tengoku
+
+This module adds basic Archipelago support for *Rhythm Tengoku* on the Game Boy Advance.
+Stages are treated as items while clearing stages acts as location checks. The required
+ranking can be configured between simple completion, obtaining a Superb score or earning a
+Perfect medal.

--- a/worlds/rhythm_tengoku/docs/setup/en.md
+++ b/worlds/rhythm_tengoku/docs/setup/en.md
@@ -1,0 +1,6 @@
+# Rhythm Tengoku Setup Guide
+
+1. Obtain a clean Japanese *Rhythm Tengoku* ROM. Archipelago cannot provide this.
+2. Apply the Archipelago patch file (`.aprt`) using the Archipelago launcher or
+   command line. The patcher will ask for your ROM file.
+3. Launch the patched ROM in BizHawk 2.7 or later and connect to your multiworld.

--- a/worlds/rhythm_tengoku/items.py
+++ b/worlds/rhythm_tengoku/items.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Dict
+
+from BaseClasses import Item, ItemClassification
+
+
+@dataclass
+class ItemData:
+    code: int
+    classification: ItemClassification
+
+
+level_names = [f"Stage {i}" for i in range(1, 49)]
+
+item_table: Dict[str, ItemData] = {
+    name: ItemData(1000 + idx, ItemClassification.progression)
+    for idx, name in enumerate(level_names)
+}
+
+
+class RhythmTengokuItem(Item):
+    game: str = "Rhythm Tengoku"

--- a/worlds/rhythm_tengoku/locations.py
+++ b/worlds/rhythm_tengoku/locations.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import Dict
+
+from BaseClasses import Location
+
+
+@dataclass
+class LocationData:
+    id: int
+
+
+location_table: Dict[str, LocationData] = {
+    name: LocationData(2000 + idx)
+    for idx, name in enumerate([f"Stage {i}" for i in range(1, 49)])
+}
+
+
+class RhythmTengokuLocation(Location):
+    game: str = "Rhythm Tengoku"

--- a/worlds/rhythm_tengoku/options.py
+++ b/worlds/rhythm_tengoku/options.py
@@ -1,0 +1,12 @@
+from Options import Choice
+
+class CheckType(Choice):
+    """Which rank is required to clear a stage."""
+    display_name = "Stage Check Type"
+    option_completion = 0
+    option_superb = 1
+    option_perfect = 2
+
+
+class RhythmTengokuOptions:
+    check_type: CheckType

--- a/worlds/rhythm_tengoku/rom.py
+++ b/worlds/rhythm_tengoku/rom.py
@@ -1,0 +1,27 @@
+import os
+from typing import TYPE_CHECKING
+
+from worlds.Files import APProcedurePatch, APTokenMixin, APTokenTypes
+
+if TYPE_CHECKING:
+    from . import RhythmTengokuWorld
+
+
+class RhythmTengokuProcedurePatch(APProcedurePatch, APTokenMixin):
+    game = "Rhythm Tengoku"
+    hash = ""
+    patch_file_ending = ".aprt"
+    result_file_ending = ".gba"
+    procedure = [
+        ("apply_bsdiff4", ["base_patch.bsdiff4"]),
+        ("apply_tokens", ["token_data.bin"])
+    ]
+
+    @classmethod
+    def get_source_data(cls) -> bytes:
+        raise FileNotFoundError("Rhythm Tengoku base ROM not provided")
+
+
+def write_tokens(world: "RhythmTengokuWorld", patch: RhythmTengokuProcedurePatch) -> None:
+    # Placeholder for token data such as connection info
+    patch.write_token(APTokenTypes.WRITE, 0x0, b"AP")


### PR DESCRIPTION
## Summary
- add a minimal world implementation for Rhythm Tengoku
- implement configurable check type option
- document the world and a short setup guide

## Testing
- `pytest -k RhythmTengoku -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687d3c1afbe0832bbd8200d3d6017f1e