### PR TITLE
Scaffold Rhythm Tengoku apworld

### DIFF
--- a/worlds/rhythm_tengoku/Items.py
+++ b/worlds/rhythm_tengoku/Items.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import ClassVar, Dict
+
+from BaseClasses import Item, ItemClassification
+
+
+class RhythmTengokuItem(Item):
+    """Archipelago representation of a Rhythm Tengoku item."""
+    game: ClassVar[str] = "Rhythm Tengoku"
+
+
+# Minimal item table; extend with actual game items later.
+item_table: Dict[str, int] = {
+    "Beat Game": 1,
+}

--- a/worlds/rhythm_tengoku/Locations.py
+++ b/worlds/rhythm_tengoku/Locations.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import ClassVar, Dict
+
+from BaseClasses import Location
+
+
+class RhythmTengokuLocation(Location):
+    """Archipelago location for Rhythm Tengoku."""
+    game: ClassVar[str] = "Rhythm Tengoku"
+
+
+# Minimal location table; extend with real stage checks later.
+location_table: Dict[str, int] = {
+    "Beat Game": 1,
+}

--- a/worlds/rhythm_tengoku/Options.py
+++ b/worlds/rhythm_tengoku/Options.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+from Options import PerGameCommonOptions
+
+
+@dataclass
+class RhythmTengokuOptions(PerGameCommonOptions):
+    """Game-specific options for Rhythm Tengoku."""
+    # Add custom options here
+    pass

--- a/worlds/rhythm_tengoku/Regions.py
+++ b/worlds/rhythm_tengoku/Regions.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from BaseClasses import MultiWorld, Region, Entrance
+
+from .Locations import RhythmTengokuLocation, location_table
+
+
+def create_regions(multiworld: MultiWorld, player: int) -> None:
+    """Create the basic world regions and link them."""
+    menu = Region("Menu", player, multiworld)
+    game_region = Region("Rhythm Tengoku", player, multiworld)
+
+    beat_game = RhythmTengokuLocation(player, "Beat Game", location_table["Beat Game"], game_region)
+    game_region.locations.append(beat_game)
+
+    start = Entrance(player, "Start Game", menu)
+    menu.exits.append(start)
+    start.connect(game_region)
+
+    multiworld.regions.extend([menu, game_region])

--- a/worlds/rhythm_tengoku/Rules.py
+++ b/worlds/rhythm_tengoku/Rules.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from BaseClasses import MultiWorld
+
+
+def set_rules(multiworld: MultiWorld, player: int) -> None:
+    """Define basic access rules and the win condition."""
+    # Placeholder completion condition: require the Beat Game item
+    multiworld.completion_condition[player] = lambda state: state.has("Beat Game", player)

--- a/worlds/rhythm_tengoku/__init__.py
+++ b/worlds/rhythm_tengoku/__init__.py
@@ -1,52 +1,42 @@
-from typing import ClassVar
+from __future__ import annotations
 
-from BaseClasses import Region, Entrance, Location, Item, ItemClassification
+from BaseClasses import Item, ItemClassification
 from worlds.AutoWorld import World
-from Options import PerGameCommonOptions
 
+from .Items import RhythmTengokuItem, item_table
+from .Locations import location_table
+from .Regions import create_regions
+from .Rules import set_rules
+from .Options import RhythmTengokuOptions
 from .client import RhythmTengokuClient  # required for BizHawk registration
 
 
-class RhythmTengokuItem(Item):
-    game: ClassVar[str] = "Rhythm Tengoku"
-
-
-class RhythmTengokuLocation(Location):
-    game: ClassVar[str] = "Rhythm Tengoku"
-
-
 class RhythmTengokuWorld(World):
+    """Minimal Archipelago world definition for Rhythm Tengoku."""
     game = "Rhythm Tengoku"
-    options_dataclass = PerGameCommonOptions
     topology_present = False
+    options_dataclass = RhythmTengokuOptions
 
-    item_name_to_id = {
-        "Beat Game": 1,
-    }
-    location_name_to_id = {
-        "Beat Game": 1,
-    }
+    item_name_to_id = item_table
+    location_name_to_id = location_table
 
     def create_item(self, name: str) -> Item:
-        return RhythmTengokuItem(name, ItemClassification.progression, self.item_name_to_id[name], self.player)
-
-    def create_regions(self) -> None:
-        menu = Region("Menu", self.player, self.multiworld)
-        game_region = Region("Rhythm Tengoku", self.player, self.multiworld)
-        self.multiworld.regions += [menu, game_region]
-
-        start_entrance = Entrance(self.player, "Start Game", menu)
-        menu.exits.append(start_entrance)
-        start_entrance.connect(game_region)
-
-        beat_game_location = RhythmTengokuLocation(self.player, "Beat Game", None, game_region)
-        game_region.locations.append(beat_game_location)
+        return RhythmTengokuItem(name, ItemClassification.progression, item_table[name], self.player)
 
     def create_items(self) -> None:
-        self.multiworld.itempool.append(self.create_item("Beat Game"))
+        for item_name in item_table:
+            self.multiworld.itempool.append(self.create_item(item_name))
+
+    def create_regions(self) -> None:
+        create_regions(self.multiworld, self.player)
 
     def set_rules(self) -> None:
+        set_rules(self.multiworld, self.player)
+
+    def generate_output(self, output_directory: str) -> None:
+        # TODO: generate patched ROM and spoiler log
         pass
 
     def fill_slot_data(self):
+        # TODO: provide slot-specific data for clients
         return {}

--- a/worlds/rhythm_tengoku/client.py
+++ b/worlds/rhythm_tengoku/client.py
@@ -12,10 +12,16 @@ class RhythmTengokuClient(BizHawkClient):
     game = "Rhythm Tengoku"
     patch_suffix = ".aprhtg"
 
+    # Placeholder memory address for checking game completion
+    GAME_COMPLETE_ADDR = 0x02000000
+
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         ctx.game = self.game
         ctx.items_handling = 0b111
         return True
 
     async def game_watcher(self, ctx: "BizHawkClientContext") -> None:
-        await asyncio.sleep(0)
+        while True:
+            # Example memory read; replace with actual game state checks
+            await ctx.read_u8(self.GAME_COMPLETE_ADDR)
+            await asyncio.sleep(1 / 60)


### PR DESCRIPTION
## Summary
- add minimal Rhythm Tengoku world scaffold including items, locations, regions, rules, options and client
- stub generate_output, fill_slot_data and basic BizHawk memory watcher
- provide placeholder completion condition and item/location tables

## Testing
- `pytest test/general/test_implemented.py::TestImplemented::test_completion_condition`

------
https://chatgpt.com/codex/tasks/task_e_688cb543ce00832b8ccd156fed7ffe15